### PR TITLE
Refactor: Move cities controllers to a dedicated folder

### DIFF
--- a/app/Http/Controllers/Cities/DestroyCityController.php
+++ b/app/Http/Controllers/Cities/DestroyCityController.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace App\Http\Controllers;
+namespace App\Http\Controllers\Cities;
 
 use App\Models\City;
 use Flugg\Responder\Contracts\Responder;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\JsonResponse;
 
-class DestroyCityController extends Controller
+class DestroyCityController
 {
     public function __invoke(int $id, Responder $responder): JsonResponse
     {

--- a/app/Http/Controllers/Cities/GetAllCitiesController.php
+++ b/app/Http/Controllers/Cities/GetAllCitiesController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Controllers;
+namespace App\Http\Controllers\Cities;
 
 use App\Models\City;
 use App\Transformers\CityTransformer;
@@ -9,7 +9,7 @@ use Illuminate\Database\QueryException;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 
-class GetAllCitiesController extends Controller
+class GetAllCitiesController
 {
     public function __invoke(Request $request, Responder $responder): JsonResponse
     {

--- a/app/Http/Controllers/Cities/StoreCityController.php
+++ b/app/Http/Controllers/Cities/StoreCityController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Controllers;
+namespace App\Http\Controllers\Cities;
 
 use App\Http\Requests\StoreCityRequest;
 use App\Models\City;
@@ -8,7 +8,7 @@ use App\Transformers\CityTransformer;
 use Flugg\Responder\Contracts\Responder;
 use Illuminate\Http\JsonResponse;
 
-class CreateCityController extends Controller
+class StoreCityController
 {
     public function __invoke(StoreCityRequest $request, Responder $responder): JsonResponse
     {

--- a/app/Http/Controllers/Cities/UpdateCityController.php
+++ b/app/Http/Controllers/Cities/UpdateCityController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Http\Controllers;
+namespace App\Http\Controllers\Cities;
 
 use App\Http\Requests\StoreCityRequest;
 use App\Models\City;
@@ -9,7 +9,7 @@ use Flugg\Responder\Contracts\Responder;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\JsonResponse;
 
-class UpdateCityController extends Controller
+class UpdateCityController
 {
     public function __invoke(StoreCityRequest $request, int $id, Responder $responder): JsonResponse
     {

--- a/app/Http/Controllers/Cities/ViewCitiesController.php
+++ b/app/Http/Controllers/Cities/ViewCitiesController.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace App\Http\Controllers;
+namespace App\Http\Controllers\Cities;
 
 use Illuminate\Contracts\View\View;
 
-class ViewCitiesController extends Controller
+class ViewCitiesController
 {
     public function __invoke(): View
     {

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -1,7 +1,0 @@
-<?php
-
-namespace App\Http\Controllers;
-
-abstract class Controller
-{
-}

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,14 +1,14 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
-use App\Http\Controllers\CreateCityController;
-use App\Http\Controllers\DestroyCityController;
-use App\Http\Controllers\GetAllCitiesController;
-use App\Http\Controllers\UpdateCityController;
+use App\Http\Controllers\Cities\StoreCityController;
+use App\Http\Controllers\Cities\DestroyCityController;
+use App\Http\Controllers\Cities\GetAllCitiesController;
+use App\Http\Controllers\Cities\UpdateCityController;
 
 Route::prefix('cities')->name('cities.')->group(function () {
     Route::get('/', GetAllCitiesController::class)->name('index');
-    Route::post('/', CreateCityController::class)->name('store');
-    Route::put('/{id}', UpdateCityController::class)->name('update');
+    Route::post('/', StoreCityController::class)->name('store');
+    Route::patch('/{id}', UpdateCityController::class)->name('update');
     Route::delete('/{id}', DestroyCityController::class)->name('destroy');
 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -9,6 +9,6 @@ use App\Http\Controllers\Cities\UpdateCityController;
 Route::prefix('cities')->name('cities.')->group(function () {
     Route::get('/', GetAllCitiesController::class)->name('index');
     Route::post('/', StoreCityController::class)->name('store');
-    Route::patch('/{id}', UpdateCityController::class)->name('update');
+    Route::put('/{id}', UpdateCityController::class)->name('update');
     Route::delete('/{id}', DestroyCityController::class)->name('destroy');
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,8 +1,7 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
-use App\Http\Controllers\CityController;
-use App\Http\Controllers\ViewCitiesController;
+use App\Http\Controllers\Cities\ViewCitiesController;
 
 Route::view('/', 'dashboard');
 


### PR DESCRIPTION
Refactor: Move cities controllers to a dedicated folder

## Description ⭐

This PR moves all the controllers regarding the cities resource to a new folder inside the controllers. The CreateCityController was renamed to StoreCityController in order to follow Laravel's naming conventions.

### Type of change 🏃

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality not to work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested? ❓

No testing added to the project yet.
